### PR TITLE
Add support for Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
         target:
         - x86_64-unknown-linux-gnu
         - i686-unknown-linux-gnu
+        - x86_64-pc-windows-gnu
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,12 @@ jobs:
       if: matrix.target == 'x86_64-pc-windows-gnu'
       run: sudo apt -y install mingw-w64
     - run: cargo build --verbose --release --target ${{ matrix.target }}
-    - name: Rename artifact
+    - name: Rename artifact (linux)
+      if: matrix.target != 'x86_64-pc-windows-gnu'
       run: mv target/${{ matrix.target }}/release/${{ github.event.repository.name }} ${{ github.event.repository.name }}-${{ matrix.target }}
+    - name: Rename artifact (windows)
+      if: matrix.target == 'x86_64-pc-windows-gnu'
+      run: mv target/${{ matrix.target }}/release/${{ github.event.repository.name }}.exe ${{ github.event.repository.name }}-${{ matrix.target }}.exe
     - uses: actions/upload-artifact@v3
       with:
         path: ${{ github.event.repository.name }}-${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,11 @@ jobs:
       run: |
         sudo apt update
         sudo apt -y install gcc-multilib
+        sudo apt 
         rustup target add ${{ matrix.target }}
+    - name: Install build dependency for windows
+      if: matrix.target = 'x86_64-pc-windows-gnu'
+      run: sudo apt -y install mingw-w64
     - run: cargo build --verbose --release --target ${{ matrix.target }}
     - name: Rename artifact
       run: mv target/${{ matrix.target }}/release/${{ github.event.repository.name }} ${{ github.event.repository.name }}-${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         sudo apt 
         rustup target add ${{ matrix.target }}
     - name: Install build dependency for windows
-      if: matrix.target = 'x86_64-pc-windows-gnu'
+      if: matrix.target == 'x86_64-pc-windows-gnu'
       run: sudo apt -y install mingw-w64
     - run: cargo build --verbose --release --target ${{ matrix.target }}
     - name: Rename artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,9 @@ jobs:
       run: mv target/${{ matrix.target }}/release/${{ github.event.repository.name }}.exe ${{ github.event.repository.name }}-${{ matrix.target }}.exe
     - uses: actions/upload-artifact@v3
       with:
-        path: ${{ github.event.repository.name }}-${{ matrix.target }}
+        path: |
+          ${{ github.event.repository.name }}-${{ matrix.target }}
+          ${{ github.event.repository.name }}-${{ matrix.target }}.exe
         retention-days: 1
   release:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,6 @@ jobs:
       run: |
         sudo apt update
         sudo apt -y install gcc-multilib
-        sudo apt 
         rustup target add ${{ matrix.target }}
     - name: Install build dependency for windows
       if: matrix.target == 'x86_64-pc-windows-gnu'

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![windows_subsystem = "windows"]
+
 extern crate rayon;
 extern crate softbuffer;
 extern crate winit;


### PR DESCRIPTION
Due to popular demand (#1), this PR implements support for Microsoft Windows®.

Firstly, the rather annoying than useful console window gets hidden, by defining `#![windows_subsystem = "windows"]` in the `main.rs`.

Additionally, the windows binary will now be built in the `release` action and published correctly. Due to windows exclusive and unnecessary `.exe` file extension for executables, this adds some amount of complexity.

Fun fact: All of this was done on linux.